### PR TITLE
make-wavefront-nozzle-more-robust-to-failures

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,8 @@ applications:
   path: <ReplaceMe with path to the wavefront-nozzle JAR>
   buildpack: https://github.com/cloudfoundry/java-buildpack.git 
   env:
+    # Reactor HTTP client settings
+    JAVA_OPTS: '-Dreactor.ipc.netty.pool.maxConnections=32'
     # PCF properties
     # Replace the values below
     pcf.host: <ReplaceMe with PCF FQDN. Example: api.local.pcfdev.io>
@@ -21,6 +23,10 @@ applications:
     # Choose a value between 1 and 8 inclusive. Default to 4
     pcf.firehose.parallelism: 4
     pcf.firehose.subscriptionId: firehose-to-wavefront-proxy
+    # PCF AppInfo properties
+    pcf.appInfo.fetchAppInfo: true
+    pcf.appInfo.appInfoCacheSize: 5000
+    pcf.appInfo.cacheExpireIntervalHours: 6
     # Wavefront-Proxy properties
     wavefront.proxy.hostname: <ReplaceMe>
     wavefront.proxy.port: <ReplaceMe>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,13 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.0.6.RELEASE</version>
+            <version>3.0.7.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.cloudfoundry</groupId>
             <artifactId>cloudfoundry-client-reactor</artifactId>
-            <version>2.3.0.RELEASE</version>
+            <version>2.16.0.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-nozzle</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>wavefront-nozzle</name>
@@ -79,6 +80,11 @@
             <version>3.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.5.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/wavefront/config/BeansConfiguration.java
+++ b/src/main/java/com/wavefront/config/BeansConfiguration.java
@@ -1,9 +1,11 @@
 package com.wavefront.config;
 
+import com.wavefront.props.AppInfoProperties;
 import com.wavefront.props.FirehoseProperties;
 import com.wavefront.props.PcfProperties;
 import com.wavefront.props.WavefrontProxyProperties;
 import com.wavefront.service.FirehoseToWavefrontProxyConnector;
+
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
@@ -24,10 +26,13 @@ import java.util.logging.Logger;
  * @author Sushant Dewan (sushant@wavefront.com).
  */
 @Configuration
-@EnableConfigurationProperties({PcfProperties.class, WavefrontProxyProperties.class, FirehoseProperties.class})
+@EnableConfigurationProperties({PcfProperties.class, WavefrontProxyProperties.class,
+    FirehoseProperties.class, AppInfoProperties.class})
 public class BeansConfiguration {
 
-  private static final Logger logger = Logger.getLogger(BeansConfiguration.class.getCanonicalName());
+  private static final Logger logger = Logger.getLogger(
+      BeansConfiguration.class.getCanonicalName());
+  private static final String NETTY_MAX_CONNECTIONS_PROP = "reactor.ipc.netty.pool.maxConnections";
 
   @Autowired
   private FirehoseToWavefrontProxyConnector firehoseToWavefrontProxyConnector;
@@ -39,29 +44,34 @@ public class BeansConfiguration {
 
   @Bean
   public DefaultConnectionContext connectionContext(PcfProperties pcfProperties) {
+    // Set property if not already set
+    System.setProperty(NETTY_MAX_CONNECTIONS_PROP,
+        System.getProperty(NETTY_MAX_CONNECTIONS_PROP, "32"));
+    logger.info("Using reactor.ipc.netty.pool.maxConnections: " +
+        System.getProperty("reactor.ipc.netty.pool.maxConnections"));
     return DefaultConnectionContext.builder().apiHost(pcfProperties.getHost()).
-            skipSslValidation(pcfProperties.isSkipSslValidation()).build();
+        skipSslValidation(pcfProperties.isSkipSslValidation()).build();
   }
 
   @Bean
   public PasswordGrantTokenProvider tokenProvider(PcfProperties pcfProperties) {
     logger.info(String.format("Using PCF properties, host: %s and user: %s",
-            pcfProperties.getHost(), pcfProperties.getUser()));
+        pcfProperties.getHost(), pcfProperties.getUser()));
     return PasswordGrantTokenProvider.builder().username(pcfProperties.getUser()).
-            password(pcfProperties.getPassword()).build();
+        password(pcfProperties.getPassword()).build();
   }
 
   @Bean
   public ReactorCloudFoundryClient cloudFoundryClient(ConnectionContext connectionContext,
                                                       TokenProvider tokenProvider) {
     return ReactorCloudFoundryClient.builder().connectionContext(connectionContext).
-            tokenProvider(tokenProvider).build();
+        tokenProvider(tokenProvider).build();
   }
 
   @Bean
   public ReactorDopplerClient dopplerClient(ConnectionContext connectionContext,
                                             TokenProvider tokenProvider) {
     return ReactorDopplerClient.builder().connectionContext(connectionContext).
-            tokenProvider(tokenProvider).build();
+        tokenProvider(tokenProvider).build();
   }
 }

--- a/src/main/java/com/wavefront/config/BeansConfiguration.java
+++ b/src/main/java/com/wavefront/config/BeansConfiguration.java
@@ -9,6 +9,7 @@ import com.wavefront.service.FirehoseToWavefrontProxyConnector;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.doppler.ReactorDopplerClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +59,13 @@ public class BeansConfiguration {
         pcfProperties.getHost(), pcfProperties.getUser()));
     return PasswordGrantTokenProvider.builder().username(pcfProperties.getUser()).
         password(pcfProperties.getPassword()).build();
+  }
+
+  @Bean
+  public ReactorCloudFoundryClient cloudFoundryClient(ConnectionContext connectionContext,
+                                                      TokenProvider tokenProvider) {
+    return ReactorCloudFoundryClient.builder().connectionContext(connectionContext).
+        tokenProvider(tokenProvider).build();
   }
 
   @Bean

--- a/src/main/java/com/wavefront/config/BeansConfiguration.java
+++ b/src/main/java/com/wavefront/config/BeansConfiguration.java
@@ -9,7 +9,6 @@ import com.wavefront.service.FirehoseToWavefrontProxyConnector;
 import org.cloudfoundry.reactor.ConnectionContext;
 import org.cloudfoundry.reactor.DefaultConnectionContext;
 import org.cloudfoundry.reactor.TokenProvider;
-import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
 import org.cloudfoundry.reactor.doppler.ReactorDopplerClient;
 import org.cloudfoundry.reactor.tokenprovider.PasswordGrantTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,13 +58,6 @@ public class BeansConfiguration {
         pcfProperties.getHost(), pcfProperties.getUser()));
     return PasswordGrantTokenProvider.builder().username(pcfProperties.getUser()).
         password(pcfProperties.getPassword()).build();
-  }
-
-  @Bean
-  public ReactorCloudFoundryClient cloudFoundryClient(ConnectionContext connectionContext,
-                                                      TokenProvider tokenProvider) {
-    return ReactorCloudFoundryClient.builder().connectionContext(connectionContext).
-        tokenProvider(tokenProvider).build();
   }
 
   @Bean

--- a/src/main/java/com/wavefront/props/AppInfoProperties.java
+++ b/src/main/java/com/wavefront/props/AppInfoProperties.java
@@ -1,0 +1,50 @@
+package com.wavefront.props;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * PCF AppInfo properties getters and setters
+ *
+ * @author Sushant Dewan (sushant@wavefront.com).
+ */
+@ConfigurationProperties(prefix = "pcf.appInfo")
+public class AppInfoProperties {
+  /**
+   * Whether to fetch PCF app info or not
+   */
+  private boolean fetchAppInfo;
+
+  /**
+   * AppInfo is cached. Tune the cache size using this variable
+   */
+  private int appInfoCacheSize;
+
+  /**
+   * Entries in cache expire after write. Tune this interval using this variable
+   */
+  private int cacheExpireIntervalHours;
+
+  public boolean isFetchAppInfo() {
+    return fetchAppInfo;
+  }
+
+  public void setFetchAppInfo(boolean fetchAppInfo) {
+    this.fetchAppInfo = fetchAppInfo;
+  }
+
+  public int getAppInfoCacheSize() {
+    return appInfoCacheSize;
+  }
+
+  public void setAppInfoCacheSize(int appInfoCacheSize) {
+    this.appInfoCacheSize = appInfoCacheSize;
+  }
+
+  public int getCacheExpireIntervalHours() {
+    return cacheExpireIntervalHours;
+  }
+
+  public void setCacheExpireIntervalHours(int cacheExpireIntervalHours) {
+    this.cacheExpireIntervalHours = cacheExpireIntervalHours;
+  }
+}

--- a/src/main/java/com/wavefront/props/FirehoseProperties.java
+++ b/src/main/java/com/wavefront/props/FirehoseProperties.java
@@ -12,8 +12,16 @@ import java.util.List;
  */
 @ConfigurationProperties(prefix = "pcf.firehose")
 public class FirehoseProperties {
+  /**
+   * List of event types you want to send to wavefront
+   */
   private List<EventType> eventTypes;
+
+  /**
+   * Firehose request subscription ID
+   */
   private String subscriptionId;
+
   /**
    * By default 4 threads sending metrics to proxy
    */

--- a/src/main/java/com/wavefront/proxy/ProxyForwarder.java
+++ b/src/main/java/com/wavefront/proxy/ProxyForwarder.java
@@ -1,6 +1,7 @@
 package com.wavefront.proxy;
 
 import com.wavefront.model.AppEnvelope;
+
 import org.springframework.stereotype.Component;
 
 /**

--- a/src/main/java/com/wavefront/service/AppInfoFetcher.java
+++ b/src/main/java/com/wavefront/service/AppInfoFetcher.java
@@ -1,10 +1,12 @@
 package com.wavefront.service;
 
 import com.wavefront.model.AppInfo;
+
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
 
 import java.util.Optional;
+
+import reactor.core.publisher.Mono;
 
 /**
  * Service to fetch PCF Application details for given applicationId

--- a/src/main/java/com/wavefront/service/CachedAppInfoFetcher.java
+++ b/src/main/java/com/wavefront/service/CachedAppInfoFetcher.java
@@ -1,8 +1,11 @@
 package com.wavefront.service;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.wavefront.model.AppInfo;
+import com.wavefront.props.AppInfoProperties;
+
 import org.cloudfoundry.client.CloudFoundryClient;
 import org.cloudfoundry.client.v2.applications.ApplicationEntity;
 import org.cloudfoundry.client.v2.applications.GetApplicationRequest;
@@ -13,13 +16,15 @@ import org.cloudfoundry.client.v2.spaces.SpaceEntity;
 import org.cloudfoundry.util.ResourceUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
-import reactor.util.function.Tuples;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
 
 import static org.cloudfoundry.util.tuple.TupleUtils.function;
 
@@ -31,65 +36,69 @@ import static org.cloudfoundry.util.tuple.TupleUtils.function;
 @Component
 public class CachedAppInfoFetcher implements AppInfoFetcher {
 
-  private static final Logger logger = Logger.getLogger(CachedAppInfoFetcher.class.getCanonicalName());
+  private static final Logger logger = Logger.getLogger(
+      CachedAppInfoFetcher.class.getCanonicalName());
+
   /**
-   * We can tune this constant if needed ...
+   * How long to wait to receive AppInfo from PCF
    */
-  private static final int NUM_PCF_APPS = 5000;
-  /**
-   * AppData is mutable, so refresh the data every 1 hour
-   */
-  private static final int REFRESH_INTERVAL_HOUR = 1;
-  private final Cache<String, AppInfo> cache = CacheBuilder.newBuilder().
-          expireAfterWrite(REFRESH_INTERVAL_HOUR, TimeUnit.HOURS).maximumSize(NUM_PCF_APPS).build();
+  private static final int PCF_FETCH_TIMEOUT_SECONDS = 10;
+  private final Cache<String, Optional<AppInfo>> cache;
 
   @Autowired
   private CloudFoundryClient cfClient;
 
+  public CachedAppInfoFetcher(AppInfoProperties appInfoProperties) {
+    cache = Caffeine.newBuilder().
+        expireAfterWrite(appInfoProperties.getCacheExpireIntervalHours(), TimeUnit.HOURS).
+        maximumSize(appInfoProperties.getAppInfoCacheSize()).build();
+  }
+
   @Override
   public Mono<Optional<AppInfo>> fetch(String applicationId) {
-    // cache.get is thread safe
-    AppInfo appInfo = cache.getIfPresent(applicationId);
-    if (appInfo == null) {
+    // Note - cache.get is thread safe
+    Optional<AppInfo> optionalAppInfo = cache.getIfPresent(applicationId);
+    if (optionalAppInfo == null) {
       // not present in the cache ...
-      return fetchFromPcf(applicationId).doOnNext(optionalAppInfo -> {
-        if (optionalAppInfo.isPresent()) {
-          // cache.put is thread safe
-          cache.put(applicationId, optionalAppInfo.get());
-        }
+      return fetchFromPcf(applicationId).doOnNext(item -> {
+        // Put optionalAppInfo in the cache irrespective of whether value is present or not ...
+        // Note - cache.put is thread safe
+        cache.put(applicationId, item);
       });
     } else {
       // return cached value ...
-      return Mono.just(Optional.of(appInfo));
+      return Mono.just(optionalAppInfo);
     }
   }
 
   private Mono<Optional<AppInfo>> fetchFromPcf(String applicationId) {
     return getApplication(applicationId).
-            then(app -> getSpace(app.getSpaceId()).map(space -> Tuples.of(space, app))).
-            then(function((space, app) -> getOrganization(space.getOrganizationId()).
-                    map(org -> Optional.of(new AppInfo(app.getName(), org.getName(), space.getName()))))).
-            otherwise(t -> {
-              logger.log(Level.WARNING, "Unable to fetch app details for applicationId:" + applicationId, t);
-              return Mono.just(Optional.empty());
-            });
+        then(app -> getSpace(app.getSpaceId()).map(space -> Tuples.of(space, app))).
+        then(function((space, app) -> getOrganization(space.getOrganizationId()).
+            map(org -> Optional.of(new AppInfo(app.getName(), org.getName(), space.getName()))))).
+        timeout(Duration.ofSeconds(PCF_FETCH_TIMEOUT_SECONDS)).
+        otherwise(t -> {
+          logger.log(Level.WARNING, "Unable to fetch app details for applicationId:" +
+              applicationId, t);
+          return Mono.just(Optional.empty());
+        });
   }
 
   private Mono<ApplicationEntity> getApplication(String applicationId) {
     return cfClient.applicationsV2()
-            .get(GetApplicationRequest.builder().applicationId(applicationId).build())
-            .map(ResourceUtils::getEntity);
+        .get(GetApplicationRequest.builder().applicationId(applicationId).build())
+        .map(ResourceUtils::getEntity);
   }
 
   private Mono<SpaceEntity> getSpace(String spaceid) {
     return cfClient.spaces()
-            .get(GetSpaceRequest.builder().spaceId(spaceid).build())
-            .map(ResourceUtils::getEntity);
+        .get(GetSpaceRequest.builder().spaceId(spaceid).build())
+        .map(ResourceUtils::getEntity);
   }
 
   private Mono<OrganizationEntity> getOrganization(String orgId) {
     return cfClient.organizations()
-            .get(GetOrganizationRequest.builder().organizationId(orgId).build())
-            .map(ResourceUtils::getEntity);
+        .get(GetOrganizationRequest.builder().organizationId(orgId).build())
+        .map(ResourceUtils::getEntity);
   }
 }

--- a/src/main/java/com/wavefront/service/FirehoseToWavefrontProxyConnectorImpl.java
+++ b/src/main/java/com/wavefront/service/FirehoseToWavefrontProxyConnectorImpl.java
@@ -1,19 +1,23 @@
 package com.wavefront.service;
 
 import com.wavefront.model.AppEnvelope;
+import com.wavefront.props.AppInfoProperties;
 import com.wavefront.props.FirehoseProperties;
 import com.wavefront.proxy.ProxyForwarder;
+
 import org.cloudfoundry.doppler.DopplerClient;
 import org.cloudfoundry.doppler.EventType;
 import org.cloudfoundry.doppler.FirehoseRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import static com.wavefront.utils.Constants.WAVEFRONT_FIREHOSE_NOZZLE;
 
@@ -25,7 +29,8 @@ import static com.wavefront.utils.Constants.WAVEFRONT_FIREHOSE_NOZZLE;
 @Component
 public class FirehoseToWavefrontProxyConnectorImpl implements FirehoseToWavefrontProxyConnector {
 
-  private static final Logger logger = Logger.getLogger(FirehoseToWavefrontProxyConnectorImpl.class.getCanonicalName());
+  private static final Logger logger = Logger.getLogger(
+      FirehoseToWavefrontProxyConnectorImpl.class.getCanonicalName());
 
   @Autowired
   private DopplerClient dopplerClient;
@@ -34,15 +39,22 @@ public class FirehoseToWavefrontProxyConnectorImpl implements FirehoseToWavefron
   private FirehoseProperties firehoseProperties;
 
   @Autowired
+  private AppInfoProperties appInfoProperties;
+
+  @Autowired
   private ProxyForwarder proxyForwarder;
 
   @Autowired
   private AppInfoFetcher appInfoFetcher;
 
-  public FirehoseToWavefrontProxyConnectorImpl(DopplerClient dopplerClient, FirehoseProperties firehoseProperties,
-                                               ProxyForwarder proxyForwarder, AppInfoFetcher appInfoFetcher) {
+  public FirehoseToWavefrontProxyConnectorImpl(DopplerClient dopplerClient,
+                                               FirehoseProperties firehoseProperties,
+                                               AppInfoProperties appInfoProperties,
+                                               ProxyForwarder proxyForwarder,
+                                               AppInfoFetcher appInfoFetcher) {
     this.dopplerClient = dopplerClient;
     this.firehoseProperties = firehoseProperties;
+    this.appInfoProperties = appInfoProperties;
     this.proxyForwarder = proxyForwarder;
     this.appInfoFetcher = appInfoFetcher;
   }
@@ -50,27 +62,33 @@ public class FirehoseToWavefrontProxyConnectorImpl implements FirehoseToWavefron
   @Override
   public void connect() {
     logger.info(String.format("Connecting to firehose using subscription id: %s and " +
-                    "forwarding following event types: %s in parallel: %s",
-            firehoseProperties.getSubscriptionId(),
-            String.join(", ", firehoseProperties.getEventTypes().toString()),
-            firehoseProperties.getParallelism()));
+            "forwarding following event types: %s in parallel: %s",
+        firehoseProperties.getSubscriptionId(),
+        String.join(", ", firehoseProperties.getEventTypes().toString()),
+        firehoseProperties.getParallelism()));
 
-    dopplerClient.firehose(FirehoseRequest.builder().subscriptionId(firehoseProperties.getSubscriptionId()).build()).
-            subscribeOn(Schedulers.newParallel(WAVEFRONT_FIREHOSE_NOZZLE, firehoseProperties.getParallelism())).
-            filter(envelope -> filterEventType(envelope.getEventType())).
-            flatMap(envelope -> {
-              if (envelope.getEventType() == EventType.CONTAINER_METRIC) {
-                return appInfoFetcher.fetch(envelope.getContainerMetric().getApplicationId()).
-                        map(optionalAppInfo -> new AppEnvelope(envelope, optionalAppInfo));
-              } else {
-                return Mono.just(new AppEnvelope(envelope, Optional.empty()));
-              }
-            }).
-            subscribe(appEnvelope -> proxyForwarder.forward(appEnvelope));
+    dopplerClient.firehose(FirehoseRequest.builder().subscriptionId(
+        firehoseProperties.getSubscriptionId()).build()).
+        subscribeOn(Schedulers.newParallel(WAVEFRONT_FIREHOSE_NOZZLE,
+            firehoseProperties.getParallelism())).
+        filter(envelope -> filterEventType(envelope.getEventType())).
+        flatMap(envelope -> {
+          if (appInfoProperties.isFetchAppInfo() &&
+              envelope.getEventType() == EventType.CONTAINER_METRIC) {
+            return appInfoFetcher.fetch(envelope.getContainerMetric().getApplicationId()).
+                map(optionalAppInfo -> new AppEnvelope(envelope, optionalAppInfo));
+          } else {
+            return Mono.just(new AppEnvelope(envelope, Optional.empty()));
+          }
+        }).subscribe(appEnvelope -> proxyForwarder.forward(appEnvelope));
+    // TODO: Can apply back-pressure if nozzle cannot keep up with the firehose
+    // i.e. onBackpressureBuffer(<BUFFER_SIZE>, BufferOverflowStrategy.DROP_LATEST)
+    // need to figure out <BUFFER_SIZE> before we enable this ...
   }
 
   private boolean filterEventType(@Nullable EventType eventType) {
-    if (firehoseProperties.getEventTypes() == null || firehoseProperties.getEventTypes().size() == 0) {
+    if (firehoseProperties.getEventTypes() == null ||
+        firehoseProperties.getEventTypes().size() == 0) {
       return false;
     }
 

--- a/src/main/java/com/wavefront/utils/ContainerMetricUtils.java
+++ b/src/main/java/com/wavefront/utils/ContainerMetricUtils.java
@@ -15,6 +15,6 @@ import static com.wavefront.utils.MetricUtils.getPcfMetricNamePrefix;
 public class ContainerMetricUtils {
   public static String getMetricName(Envelope envelope, String suffix) {
     return getPcfMetricNamePrefix() + CONTAINER_PREFIX + METRICS_NAME_SEP +
-            getOrigin(envelope) + METRICS_NAME_SEP + suffix;
+        getOrigin(envelope) + METRICS_NAME_SEP + suffix;
   }
 }

--- a/src/main/java/com/wavefront/utils/CounterEventUtils.java
+++ b/src/main/java/com/wavefront/utils/CounterEventUtils.java
@@ -14,6 +14,6 @@ import static com.wavefront.utils.MetricUtils.getPcfMetricNamePrefix;
 public class CounterEventUtils {
   public static String getMetricName(Envelope envelope, String suffix) {
     return getPcfMetricNamePrefix() + getOrigin(envelope) + METRICS_NAME_SEP +
-            envelope.getCounterEvent().getName() + METRICS_NAME_SEP + suffix;
+        envelope.getCounterEvent().getName() + METRICS_NAME_SEP + suffix;
   }
 }

--- a/src/main/java/com/wavefront/utils/MetricUtils.java
+++ b/src/main/java/com/wavefront/utils/MetricUtils.java
@@ -1,18 +1,29 @@
 package com.wavefront.utils;
 
 import com.google.common.collect.Maps;
+
 import com.wavefront.model.AppEnvelope;
 import com.wavefront.model.AppInfo;
+
 import org.cloudfoundry.doppler.Envelope;
 
-import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.wavefront.utils.Constants.*;
+import javax.annotation.Nullable;
+
+import static com.wavefront.utils.Constants.APPLICATION_ID;
+import static com.wavefront.utils.Constants.APPLICATION_NAME;
+import static com.wavefront.utils.Constants.DEPLOYMENT;
+import static com.wavefront.utils.Constants.INSTANCE_INDEX;
+import static com.wavefront.utils.Constants.JOB;
+import static com.wavefront.utils.Constants.METRICS_NAME_SEP;
+import static com.wavefront.utils.Constants.ORG;
+import static com.wavefront.utils.Constants.PCF_PREFIX;
+import static com.wavefront.utils.Constants.SPACE;
 import static org.cloudfoundry.doppler.EventType.CONTAINER_METRIC;
 
 /**
@@ -83,7 +94,8 @@ public class MetricUtils {
        */
       String applicationId = envelope.getContainerMetric().getApplicationId();
       map.put(APPLICATION_ID, applicationId);
-      map.put(INSTANCE_INDEX, String.valueOf(envelope.getContainerMetric().getInstanceIndex().toString()));
+      map.put(INSTANCE_INDEX, String.valueOf(
+          envelope.getContainerMetric().getInstanceIndex().toString()));
     }
 
     /**

--- a/src/main/java/com/wavefront/utils/ValueMetricUtils.java
+++ b/src/main/java/com/wavefront/utils/ValueMetricUtils.java
@@ -13,7 +13,8 @@ import static com.wavefront.utils.MetricUtils.getPcfMetricNamePrefix;
  */
 public class ValueMetricUtils {
   public static String getMetricName(Envelope envelope) {
-    return getPcfMetricNamePrefix() + getOrigin(envelope) + METRICS_NAME_SEP + envelope.getValueMetric().getName() +
-            METRICS_NAME_SEP + envelope.getValueMetric().getUnit();
+    return getPcfMetricNamePrefix() + getOrigin(envelope) + METRICS_NAME_SEP +
+        envelope.getValueMetric().getName() + METRICS_NAME_SEP +
+        envelope.getValueMetric().getUnit();
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ pcf.user=<ReplaceMe>
 pcf.password=<ReplaceMe>
 # Replace below with either true|false
 pcf.skipSslValidation=true
+
 # Firehose properties
 # Replace the values below
 # Valid firehose event types - { COUNTER_EVENT, VALUE_METRIC, CONTAINER_METRIC, ERROR, HTTP_START_STOP, LOG_MESSAGE }
@@ -12,9 +13,13 @@ pcf.firehose.eventTypes=<Replace me with one or more values from above list. Exa
 # Choose a value between 1 and 8 inclusive. Default to 4
 pcf.firehose.parallelism=4
 pcf.firehose.subscriptionId=firehose-to-wavefront-proxy
+
+# PCF AppInfo properties
+pcf.appInfo.fetchAppInfo=true
+pcf.appInfo.appInfoCacheSize=5000
+pcf.appInfo.cacheExpireIntervalHours=6
+
 # Wavefront-Proxy properties
 # Replace the values below
 wavefront.proxy.hostname=<ReplaceMe>
 wavefront.proxy.port=<ReplaceMe>
-# Logging properties
-#logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
1. Using Caffeine cache instead of Guava Cache.
2. Also tweaked cache size and expiration after write parameters and made those values user-configurable.
3. Tuned Reactor netty client connection size to 32 and made it configurable.
4. Reformatted the code using Wavefront coding guidelines. I had missed doing some of it last time - like adhering to 100 char width.
5. Changed pom file version from 1.0.0 to 0.9.0