### PR TITLE
Add support for customTags for point metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wavefront</groupId>
     <artifactId>wavefront-nozzle</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>wavefront-nozzle</name>

--- a/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
+++ b/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
@@ -126,7 +126,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
   private void send(String metricName, double metricValue, Long timestamp, String source,
                     Map<String, String> tags) {
     // Add custom tags to the point metrics
-    // Note: Only new maps are supplied as the parameter "tags", 
+    // Note: Only new maps are supplied as the parameter "tags",
     // so no defensive copying is needed
     tags.putAll(customTags);
     try {

--- a/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
+++ b/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
@@ -126,6 +126,8 @@ public class ProxyForwarderImpl implements ProxyForwarder {
   private void send(String metricName, double metricValue, Long timestamp, String source,
                     Map<String, String> tags) {
     // Add custom tags to the point metrics
+    // Note: Only new maps are supplied as the parameter "tags", 
+    // so no defensive copying is needed
     tags.putAll(customTags);
     try {
       // The if else if condition is not needed with the latest proxy but

--- a/src/main/java/com/wavefront/utils/Constants.java
+++ b/src/main/java/com/wavefront/utils/Constants.java
@@ -32,4 +32,5 @@ public class Constants {
   public static final String INSTANCE_INDEX = "instanceIndex";
   public static final String DEPLOYMENT = "deployment";
   public static final String JOB = "job";
+  public static final String CUSTOM_TAG_PREFIX = "customTag.";
 }


### PR DESCRIPTION
Add support for customTags for point metrics, for instance, "foundation" is a custom tag that is applicable for all the PCF point metrics.
The customer installing the tile needs to add the custom tags which will be propagated as system properties with the prefix "customTag.*"
Finally, the actual tag name after the "customTag.*" prefix will be sent to Wavefront proxy along with the tag value
This makes the design extensible (if at all we want to add a new customTag tomorrow).