### PR TITLE
Monit-9753/Fixed build issue after updating to core reactor 3.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,13 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
-      <version>3.0.7.RELEASE</version>
+      <version>3.1.8.RELEASE</version>
     </dependency>
 
     <dependency>
       <groupId>org.cloudfoundry</groupId>
       <artifactId>cloudfoundry-client-reactor</artifactId>
-      <version>2.16.0.RELEASE</version>
+      <version>3.11.0.RELEASE</version>
     </dependency>
 
     <dependency>
@@ -77,7 +77,7 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
-      <version>3.4</version>
+      <version>3.6</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.wavefront</groupId>
   <artifactId>wavefront-nozzle</artifactId>
-  <version>0.9.3-SNAPSHOT</version>
+  <version>0.9.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>wavefront-nozzle</name>

--- a/src/main/java/com/wavefront/service/CachedAppInfoFetcher.java
+++ b/src/main/java/com/wavefront/service/CachedAppInfoFetcher.java
@@ -72,8 +72,8 @@ public class CachedAppInfoFetcher implements AppInfoFetcher {
   private Mono<Optional<AppInfo>> fetchFromPcf(String applicationId) {
     numFetchAppInfo.inc();
     return getApplication(applicationId).
-        then(app -> getSpace(app.getSpaceId()).map(space -> Tuples.of(space, app))).
-        then(function((space, app) -> getOrganization(space.getOrganizationId()).
+        flatMap(app -> getSpace(app.getSpaceId()).map(space -> Tuples.of(space, app))).
+        flatMap(function((space, app) -> getOrganization(space.getOrganizationId()).
             map(org -> Optional.of(new AppInfo(app.getName(), org.getName(), space.getName()))))).
         timeout(Duration.ofSeconds(PCF_FETCH_TIMEOUT_SECONDS)).
         onErrorResume(t -> {


### PR DESCRIPTION
Updating maven dependencies for reactor-core, cloudfoundry-client-reactor and easymock.
Also Fixed build issues while updating to reactor-core 3.1.x

Cc for review: @vikramraman @sushantdewan123