### PR TITLE
akodali/use tier1 java sdk for pcf nozzle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 
     <dependency>
       <groupId>com.wavefront</groupId>
-      <artifactId>java-client</artifactId>
-      <version>4.24</version>
+      <artifactId>wavefront-sdk-java</artifactId>
+      <version>0.9.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,13 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <version>2.5.4</version>

--- a/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
+++ b/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
@@ -4,9 +4,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 
 import com.codahale.metrics.Counter;
-import com.wavefront.integrations.Wavefront;
 import com.wavefront.model.AppEnvelope;
 import com.wavefront.props.WavefrontProxyProperties;
+import com.wavefront.sdk.proxy.WavefrontProxyClient;
 import com.wavefront.service.MetricsReporter;
 import com.wavefront.utils.ContainerMetricUtils;
 import com.wavefront.utils.CounterEventUtils;
@@ -52,7 +52,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
   private final Counter numCounterEventReceived;
   private final Counter numContainerMetricReceived;
   private final Counter metricsSendFailure;
-  private final Wavefront wavefront;
+  private final WavefrontProxyClient wavefront;
   private final ImmutableMap<String, String> customTags;
 
   public ProxyForwarderImpl(MetricsReporter metricsReporter,
@@ -60,7 +60,8 @@ public class ProxyForwarderImpl implements ProxyForwarder {
       throws IOException {
     logger.info(String.format("Forwarding PCF metrics to Wavefront proxy at %s:%s",
         proxyProperties.getHostname(), proxyProperties.getPort()));
-    this.wavefront = new Wavefront(proxyProperties.getHostname(), proxyProperties.getPort());
+    WavefrontProxyClient.Builder proxyBuilder = new WavefrontProxyClient.Builder(proxyProperties.getHostname());
+    this.wavefront = proxyBuilder.metricsPort(proxyProperties.getPort()).build();
 
     // Better to compute the custom tags once during init, instead of
     // doing it for every metric.send()
@@ -161,7 +162,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
       if (summaryLogger.tryAcquire()) {
         logger.info("Total number of metrics sent: " + numMetricsSent.getCount());
       }
-      wavefront.send(metricName, metricValue, timestamp, source, tags);
+      wavefront.sendMetric(metricName, metricValue, timestamp, source, tags);
     } catch (IOException e) {
       logger.log(Level.WARNING, "Can't send data to Wavefront proxy!", e);
       metricsSendFailure.inc();

--- a/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
+++ b/src/main/java/com/wavefront/proxy/ProxyForwarderImpl.java
@@ -52,7 +52,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
   private final Counter numCounterEventReceived;
   private final Counter numContainerMetricReceived;
   private final Counter metricsSendFailure;
-  private final WavefrontProxyClient wavefront;
+  private final WavefrontProxyClient wavefrontProxyClient;
   private final ImmutableMap<String, String> customTags;
 
   public ProxyForwarderImpl(MetricsReporter metricsReporter,
@@ -61,7 +61,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
     logger.info(String.format("Forwarding PCF metrics to Wavefront proxy at %s:%s",
         proxyProperties.getHostname(), proxyProperties.getPort()));
     WavefrontProxyClient.Builder proxyBuilder = new WavefrontProxyClient.Builder(proxyProperties.getHostname());
-    this.wavefront = proxyBuilder.metricsPort(proxyProperties.getPort()).build();
+    this.wavefrontProxyClient = proxyBuilder.metricsPort(proxyProperties.getPort()).build();
 
     // Better to compute the custom tags once during init, instead of
     // doing it for every metric.send()
@@ -162,7 +162,7 @@ public class ProxyForwarderImpl implements ProxyForwarder {
       if (summaryLogger.tryAcquire()) {
         logger.info("Total number of metrics sent: " + numMetricsSent.getCount());
       }
-      wavefront.sendMetric(metricName, metricValue, timestamp, source, tags);
+      wavefrontProxyClient.sendMetric(metricName, metricValue, timestamp, source, tags);
     } catch (IOException e) {
       logger.log(Level.WARNING, "Can't send data to Wavefront proxy!", e);
       metricsSendFailure.inc();


### PR DESCRIPTION
Use Tier1 sdk to send metrics for PCF nozzle.

Testing: Ran nozzle from local and sent points to nimba via proxy running locally.
https://nimba.wavefront.com/u/K8r9GWxfRP 
Customer: "Integrations-Bangalore-Dev"

Thank you,
Anil